### PR TITLE
Adapt Yosysflow

### DIFF
--- a/src/main/scala/andreasWallner/eda/YosysFlow.scala
+++ b/src/main/scala/andreasWallner/eda/YosysFlow.scala
@@ -1,8 +1,3 @@
-/**
-* Original copyright by Andreas Wallner
-* https://github.com/andreasWallner/spinalStuff/blob/master/src/main/scala/andreasWallner/eda/YosysFlow.scala
-*/
-
 package edatools
 
 import spinal.core.{HertzNumber, SpinalError, SpinalInfo, TimeNumber}

--- a/src/main/scala/andreasWallner/eda/YosysFlow.scala
+++ b/src/main/scala/andreasWallner/eda/YosysFlow.scala
@@ -1,4 +1,4 @@
-package edatools
+package andreasWallner.eda
 
 import spinal.core.{HertzNumber, SpinalError, SpinalInfo, TimeNumber}
 import spinal.lib.eda.bench.{Report, Rtl}

--- a/src/main/scala/andreasWallner/eda/YosysFlow.scala
+++ b/src/main/scala/andreasWallner/eda/YosysFlow.scala
@@ -1,4 +1,9 @@
-package andreasWallner.eda
+/**
+* Original copyright by Andreas Wallner
+* https://github.com/andreasWallner/spinalStuff/blob/master/src/main/scala/andreasWallner/eda/YosysFlow.scala
+*/
+
+package edatools
 
 import spinal.core.{HertzNumber, SpinalError, SpinalInfo, TimeNumber}
 import spinal.lib.eda.bench.{Report, Rtl}
@@ -99,7 +104,9 @@ object YosysFlow {
 
     val frequencyMHz = frequencyTarget.map(x => (x / 1e6).toDouble)
     val readRtl =
-      rtl.getRtlPaths().map(file => s"${Paths.get(file).toAbsolutePath}")
+      rtl.getRtlPaths()
+        .map(file => s"${Paths.get(file).toAbsolutePath}")
+        .filter(_.toString.split("\\.").last == "v") // filter any but .v files for now, .bin isnt parsed in yosys
     val dspArg = if (useDsp) " -dsp " else ""
     doCmd(
       Seq(
@@ -129,10 +136,10 @@ object YosysFlow {
         s"${rtl.getName()}_report.json"
       )
         ++ frequencyTarget
-          .map(x => Seq("--freq", "%f".format(x.toDouble / 1e6)))
+          .map(x => Seq("--freq", "%f".formatLocal(java.util.Locale.US, x.toDouble / 1e6)))
           .getOrElse(Seq())
         ++ pcfFile
-          .map(x => Seq("--pcf", x))
+          .map(x => Seq("--pcf", x)) 
           .getOrElse(Seq())
         ++ (if (pcfFile.isEmpty || allowUnconstrained)
               Seq("--pcf-allow-unconstrained")
@@ -144,8 +151,8 @@ object YosysFlow {
     if (frequencyTarget.isDefined) {
       doCmd(
         Seq(icestormPath + "icetime", "-d", device)
-          ++ pcfFile.map(x => Seq("-p", x)).getOrElse(Seq())
-          ++ Seq("-c", s"${frequencyMHz.get}MHz")
+          ++ pcfFile.map(x => Seq("-p", x)).getOrElse(Seq()) // NOTE: https://github.com/YosysHQ/icestorm/issues/207, pcf file is more constrained for icetime than for nextpnr
+          ++ Seq("-c", s"${frequencyMHz.get}MHz") 
           ++ Seq("-mtr", s"${rtl.getName()}.rpt", s"${rtl.getName()}.asc"),
         workspacePath,
         verbose


### PR DESCRIPTION
As mentioned in the gitter thread, I had issues with executing the flow as my project contained some files that caused errors. I was debugging it a bit and noticed some things:

1. If you have a design with `.bin` files for memory initialization, then yosys won't accept these, only Verilog files work. I added a filter for these to only accept files with Verilog file extensions (a bit hacky but it works for now)
2. After that, it ran until nextpnr was called which wouldnt work on my machine. The in an example with `Some(12 MHz)` it is passed as `12,000` MHz instead `12.000` (`.` vs `,`). This is due to the formatter relying on the locale of the machine (in my case germany/DE, where the decimal point and the thousands separator are swapped. This could be fixed by calling a formatString variant allowing for locales to be passed.
3. A minor note is: I saw that icetime only accepts very limited PCF files compared to what is accepted by nextpnr. This first caused an issue until I found the respective github issue (added link in the code for reference in case anyone should run into this). 